### PR TITLE
add shared option + add json1 option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,3 +4,9 @@ include(conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_library(sqlite3 sources/sqlite3.c)
+
+# Add some options from https://sqlite.org/compile.html
+option(ENABLE_JSON1 "Enable JSON SQL functions")
+if(ENABLE_JSON1)
+    target_compile_definitions(sqlite3 PRIVATE SQLITE_ENABLE_JSON1)
+endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,6 +16,8 @@ class ConanSqlite3(ConanFile):
     url = "http://github.com/bincrafters/conan-sqlite3"
     exports = ["CMakeLists.txt", "FindSQLite3.cmake"]
     description = "Self-contained, serverless, in-process SQL database engine."
+    options = {"shared": [True, False], "enable_json1": [True, False]}
+    default_options = "shared=False", "enable_json1=False"
     
     def source(self):
         base_url = "https://www.sqlite.org/" + self.year
@@ -29,7 +31,7 @@ class ConanSqlite3(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure()
+        cmake.configure(defs={"ENABLE_JSON1": self.options.enable_json1})
         cmake.build()
 
     def package(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -31,7 +31,8 @@ class ConanSqlite3(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(defs={"ENABLE_JSON1": self.options.enable_json1})
+        cmake.definitions["ENABLE_JSON1"] = self.options.enable_json1
+        cmake.configure()
         cmake.build()
 
     def package(self):


### PR DESCRIPTION
1. Shared version of sqlite is pretty useful in some environments.
2. Some applications rely on JSON1 module, so they will benefit from this option.

It would be great for sqlite3 packageto support more compile options from https://sqlite.org/compile.html