### PR TITLE
Fixes to support cross building to clang / Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(cmake_wrapper)
 
-include(conanbuildinfo.cmake)
+include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 if (WIN32 AND MSVC AND BUILD_SHARED_LIBS)
@@ -9,6 +9,10 @@ if (WIN32 AND MSVC AND BUILD_SHARED_LIBS)
 endif(MSVC AND BUILD_SHARED_LIBS)
 
 add_library(sqlite3 sources/sqlite3.c)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND ${ANDROID} )
+    target_compile_definitions(sqlite3 PRIVATE -DBIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD)
+endif()
 
 # Add some options from https://sqlite.org/compile.html
 option(ENABLE_JSON1 "Enable JSON SQL functions")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,10 @@ endif(MSVC AND BUILD_SHARED_LIBS)
 
 add_library(sqlite3 sources/sqlite3.c)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND ${ANDROID} )
-    target_compile_definitions(sqlite3 PRIVATE -DBIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD)
+if (${ANDROID})
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        target_compile_definitions(sqlite3 PRIVATE -DBIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD)
+    endif()
 endif()
 
 # Add some options from https://sqlite.org/compile.html


### PR DESCRIPTION
Hi, 

I've added 2 fixes to get the package to compile correctly: one so the build will work with different source/build directories. When cross-building, I've added a define that gets rid of the ambiguous call to io_ctl.  Cross-builds fine now to android with clang. 

Please consider for inclusion,
Cheers,

Rutger
