### PR TITLE
Skipped test execution if cross building on mac.

### DIFF
--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -20,6 +20,7 @@ class TestPackageConan(ConanFile):
             if self.settings.os == "Windows":
                 self.run(bin_path)
             elif self.settings.os == "Macos":
-                self.run("DYLD_LIBRARY_PATH=%s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path))
+                if not tools.cross_building(self.settings):
+                    self.run("DYLD_LIBRARY_PATH=%s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path))
             else:
                 self.run("LD_LIBRARY_PATH=%s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path))

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile, CMake, tools, RunEnvironment
+from conans import ConanFile, CMake, tools
 import os
 
 
@@ -15,13 +15,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        with tools.environment_append(RunEnvironment(self).vars):
+        if not tools.cross_building(self.settings):
             bin_path = os.path.join("bin", "test_package")
-            if self.settings.os == "Windows":
-                self.run(bin_path)
-            elif self.settings.os == "Macos":
-                if not tools.cross_building(self.settings):
-                    self.run("DYLD_LIBRARY_PATH=%s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path))
-            else:
-                if not tools.cross_building(self.settings):
-                    self.run("LD_LIBRARY_PATH=%s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path))
+            self.run(bin_path, run_environment=True)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -23,4 +23,5 @@ class TestPackageConan(ConanFile):
                 if not tools.cross_building(self.settings):
                     self.run("DYLD_LIBRARY_PATH=%s %s" % (os.environ.get('DYLD_LIBRARY_PATH', ''), bin_path))
             else:
-                self.run("LD_LIBRARY_PATH=%s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path))
+                if not tools.cross_building(self.settings):
+                    self.run("LD_LIBRARY_PATH=%s %s" % (os.environ.get('LD_LIBRARY_PATH', ''), bin_path))


### PR DESCRIPTION
Prevent the recipe from attempting to run the test executable when cross building on mac (which obviously causes an error).