### PR TITLE
enable by default option enable_column_metadata

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -33,7 +33,7 @@ class ConanSqlite3(ConanFile):
     default_options = {"shared": False,
                        "fPIC": True,
                        "threadsafe": 1,
-                       "enable_column_metadata": False,
+                       "enable_column_metadata": True,
                        "enable_explain_comments": False,
                        "enable_fts3": False,
                        "enable_fts4": False,


### PR DESCRIPTION
Qt SQL needs sqlite3 to be compiled with ENABLE_COLUMN_METADATA, because it calls `sqlite3_column_table_name16`
Currently CI is using `build_policy="missing"` to avoid failure, but that increases CI time, and it is already huge for Qt.

If you don't think that this is a good default, I could also use the `CONAN_UPLOAD_DEPENDENCIES` feature of CPT so that qt CI uploads sqlite3 binaries, the drawback being that it would roughly double the number of artifacts on bintray for sqlite3 package